### PR TITLE
Added support for relative root paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,15 +16,15 @@ module.exports = function(grunt) {
       all: [
         'Gruntfile.js',
         'tasks/*.js',
-        '<%= nodeunit.tests %>',
+        '<%= nodeunit.tests %>'
       ],
       options: {
-        jshintrc: '.jshintrc',
-      },
+        jshintrc: '.jshintrc'
+      }
     },
 
     clean: {
-      tests: ['tmp'],
+      tests: ['tmp']
     },
 
     copy: {
@@ -53,8 +53,8 @@ module.exports = function(grunt) {
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js'],
-    },
+      tests: ['test/*_test.js']
+    }
 
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
       all: [
         'Gruntfile.js',
         'tasks/*.js',
-        '<%= nodeunit.tests %>'
+        '<%= nodeunit.normal %>',
+        '<%= nodeunit.relative %>'
       ],
       options: {
         jshintrc: '.jshintrc'
@@ -48,12 +49,26 @@ module.exports = function(grunt) {
           views_root: 'tmp/views/'
         },
         src: 'tmp/views/**/*.html'
+      },
+      relative_compiled_assets: {
+          options: {
+              use_relative_root: true
+          },
+          src: 'tmp/assets/compiled/*.{css,js}'
+      },
+      relative_views: {
+        options: {
+            use_relative_root: true,
+            views_root: 'tmp/views/'
+        },
+        src: 'tmp/views/**/*.html'
       }
     },
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js']
+        normal: ['test/filerev_replace_test.js'],
+        relative:['test/filerev_replace_relative_test.js']
     }
 
   });
@@ -70,9 +85,10 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'copy', 'filerev', 'filerev_replace', 'nodeunit', 'clean']);
+  grunt.registerTask('test-normal', ['clean', 'copy', 'filerev', 'filerev_replace:compiled_assets', 'filerev_replace:views', 'nodeunit:normal', 'clean']);
+  grunt.registerTask('test-relative', ['clean', 'copy', 'filerev', 'filerev_replace:relative_compiled_assets', 'filerev_replace:relative_views', 'nodeunit:relative', 'clean']);
 
   // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'test']);
+  grunt.registerTask('default', ['jshint', 'test-normal', 'test-relative']);
 
 };

--- a/tasks/filerev_replace.js
+++ b/tasks/filerev_replace.js
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
 
   function absolute_asset_path( string, view_src, views_root ) {
     var asset_path = string.trim();
-    if( asset_path[0] != '/' && asset_path[0] != '\\' ) {
+    if( asset_path[0] !== '/' && asset_path[0] !== '\\' ) {
       asset_path = path.join( path.dirname( view_src ), asset_path );
       asset_path = file_path_to_web_path( asset_path, views_root );
     }

--- a/tasks/filerev_replace.js
+++ b/tasks/filerev_replace.js
@@ -28,11 +28,11 @@ module.exports = function(grunt) {
     });
   });
 
-  function filerev_summary_to_assets_paths( assets_root, use_relative_root ) {
+  function filerev_summary_to_assets_paths( assets_root ) {
     var assets = {};
     for( var path in grunt.filerev.summary ){
-      var src = file_path_to_web_path( path, assets_root, use_relative_root );
-      var dest = file_path_to_web_path( grunt.filerev.summary[path], assets_root, use_relative_root );
+      var src = file_path_to_web_path( path, assets_root );
+      var dest = file_path_to_web_path( grunt.filerev.summary[path], assets_root );
       var regexp = asset_path_regexp( src );
       assets[src] = { dest: dest, regexp: regexp };
     }

--- a/tasks/filerev_replace.js
+++ b/tasks/filerev_replace.js
@@ -19,19 +19,20 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('filerev_replace', 'Replace references to grunt-filerev files.', function() {
     var assets_root = this.options().assets_root;
     var views_root = this.options().views_root || assets_root;
+    var use_relative_root = (this.options().use_relative_root === true);
     var assets_paths = filerev_summary_to_assets_paths( assets_root );
 
     this.files[0].src.forEach( function( view_src ){
-      var changes = replace_assets_paths_in_view( assets_paths, view_src, views_root );
+      var changes = replace_assets_paths_in_view( assets_paths, view_src, views_root, use_relative_root );
       log_view_changes( view_src, changes );
     });
   });
 
-  function filerev_summary_to_assets_paths( assets_root ) {
+  function filerev_summary_to_assets_paths( assets_root, use_relative_root ) {
     var assets = {};
     for( var path in grunt.filerev.summary ){
-      var src = file_path_to_web_path( path, assets_root );
-      var dest = file_path_to_web_path( grunt.filerev.summary[path], assets_root );
+      var src = file_path_to_web_path( path, assets_root, use_relative_root );
+      var dest = file_path_to_web_path( grunt.filerev.summary[path], assets_root, use_relative_root );
       var regexp = asset_path_regexp( src );
       assets[src] = { dest: dest, regexp: regexp };
     }
@@ -56,16 +57,27 @@ module.exports = function(grunt) {
     return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
 
-  function replace_assets_paths_in_view( assets_paths, view_src, views_root ) {
+  function replace_assets_paths_in_view( assets_paths, view_src, views_root, use_relative_root ) {
     var view = grunt.file.read( view_src );
     var changes = [];
+
+    // base path
+    var base = '';
+
+    // should it be relative?
+    if (use_relative_root) {
+      var relative = path.relative(path.dirname(view_src), views_root);
+      if (relative) {
+        base = path.join(relative, '/');
+      }
+    }
 
     var replace_string = function( match, p1, p2, p3 ) {
       var asset_path = absolute_asset_path( p2, view_src, views_root );
 
       if( grunt.file.arePathsEquivalent( asset_path.toLowerCase(), asset_src.toLowerCase() ) ) {
         changed = true;
-        return p1 + asset_dest + p3;
+        return p1 + base + asset_dest + p3;
       } else {
         return match;
       }
@@ -73,6 +85,12 @@ module.exports = function(grunt) {
 
     for( var asset_src in assets_paths ){
       var asset_dest = assets_paths[asset_src].dest;
+
+      // relative? then remove the added slash
+      if (use_relative_root === true) {
+        asset_dest = asset_dest.substring(1);
+      }
+
       var changed = false;
 
       view = view.replace( assets_paths[asset_src].regexp, replace_string );

--- a/test/expected/assets/compiled/scripts_relative.js
+++ b/test/expected/assets/compiled/scripts_relative.js
@@ -1,0 +1,33 @@
+// Absolute path
+var path = '../images/ajax-loader.4e26f87c.gif';
+
+// Relative path
+var path = '../images/ajax-loader.4e26f87c.gif';
+var path = '../images/ajax-loader.4e26f87c.gif';
+var path = '../images/ajax-loader.4e26f87c.gif';
+
+// Delimiters
+var path = "../images/ajax-loader.4e26f87c.gif";
+var path = '<img src="../images/ajax-loader.4e26f87c.gif" />';
+var path = "var path = '../images/ajax-loader.4e26f87c.gif';";
+var path = '../images/ajax-loader.4e26f87c.gif', path = "../images/ajax-loader.4e26f87c.gif";
+
+// Escaped delimiters
+var path = "body { background: url(\"../images/ajax-loader.4e26f87c.gif\"); }";
+
+// Case insensitive
+var path = '../images/ajax-loader.4e26f87c.gif';
+
+// With query string and anchor
+var path = '../images/ajax-loader.4e26f87c.gif?a=b';
+var path = '../images/ajax-loader.4e26f87c.gif#a';
+
+// Invalid
+var path = 'ajax-loader.gif';
+var path = '/images/ajax-loader';
+var path = '/images/ajax-loader.gif.bak';
+var path = '/images/not-ajax-loader.gif';
+var path = 'images/ajax-loader.gif';
+var path = '/more/images/ajax-loader.gif';
+var path = '/cool_images/ajax-loader.gif';
+var path = 'http://othersite.com/images/ajax-loader.gif';

--- a/test/expected/assets/compiled/styles_relative.css
+++ b/test/expected/assets/compiled/styles_relative.css
@@ -1,0 +1,33 @@
+/* Absolute path */
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+
+/* Relative path */
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+
+/* Delimiters */
+body { background: url("../images/ajax-loader.4e26f87c.gif"); }
+body { background: url(../images/ajax-loader.4e26f87c.gif); }
+body { background: url(../images/ajax-loader.4e26f87c.gif); }
+body { background: url('../images/ajax-loader.4e26f87c.gif'); background: url("../images/ajax-loader.4e26f87c.gif"); }
+
+/* Escaped delimiters */
+body { content: "<img src=\"../images/ajax-loader.4e26f87c.gif\" />"; }
+
+/* Case insensitive */
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+
+/* With query string and anchor */
+body { background: url('../images/ajax-loader.4e26f87c.gif?a=b'); }
+body { background: url('../images/ajax-loader.4e26f87c.gif#a'); }
+
+/* Invalid */
+body { background: url('ajax-loader.gif'); }
+body { background: url('/images/ajax-loader'); }
+body { background: url('/images/ajax-loader.gif.bak'); }
+body { background: url('/images/not-ajax-loader.gif'); }
+body { background: url('images/ajax-loader.gif'); }
+body { background: url('/more/images/ajax-loader.gif'); }
+body { background: url('/cool_images/ajax-loader.gif'); }
+body { background: url('http://othersite.com/images/ajax-loader.gif'); }

--- a/test/expected/views/index_relative.html
+++ b/test/expected/views/index_relative.html
@@ -1,0 +1,26 @@
+<!-- Absolute path -->
+<img src="images/ajax-loader.4e26f87c.gif" />
+
+<!-- Relative path -->
+<img src="images/ajax-loader.4e26f87c.gif" />
+<img src="images/ajax-loader.4e26f87c.gif" />
+<img src="images/ajax-loader.4e26f87c.gif" />
+
+<!-- Delimiters -->
+<img src="images/ajax-loader.4e26f87c.gif" /><img src="images/ajax-loader.4e26f87c.gif" />
+
+<!-- Case insensitive -->
+<img src="images/ajax-loader.4e26f87c.gif" />
+
+<!-- With query string and anchor -->
+<img src="images/ajax-loader.4e26f87c.gif?a=b" />
+<img src="images/ajax-loader.4e26f87c.gif#a" />
+
+<!-- Invalid -->
+<img src="ajax-loader.gif" />
+<img src="/images/ajax-loader" />
+<img src="/images/ajax-loader.gif.bak" />
+<img src="/images/not-ajax-loader.gif" />
+<img src="/more/images/ajax-loader.gif" />
+<img src="/cool_images/ajax-loader.gif" />
+<img src="http://othersite.com/images/ajax-loader.gif" />

--- a/test/expected/views/media/index_relative.html
+++ b/test/expected/views/media/index_relative.html
@@ -1,0 +1,27 @@
+<!-- Absolute path -->
+<img src="../images/ajax-loader.4e26f87c.gif" />
+
+<!-- Relative path -->
+<img src="../images/ajax-loader.4e26f87c.gif" />
+<img src="../images/ajax-loader.4e26f87c.gif" />
+<img src="../images/ajax-loader.4e26f87c.gif" />
+
+<!-- Delimiters -->
+<img src="../images/ajax-loader.4e26f87c.gif" /><img src="../images/ajax-loader.4e26f87c.gif" />
+
+<!-- Case insensitive -->
+<img src="../images/ajax-loader.4e26f87c.gif" />
+
+<!-- With query string and anchor -->
+<img src="../images/ajax-loader.4e26f87c.gif?a=b" />
+<img src="../images/ajax-loader.4e26f87c.gif#a" />
+
+<!-- Invalid -->
+<img src="ajax-loader.gif" />
+<img src="/images/ajax-loader" />
+<img src="/images/ajax-loader.gif.bak" />
+<img src="/images/not-ajax-loader.gif" />
+<img src="images/ajax-loader.gif" />
+<img src="/more/images/ajax-loader.gif" />
+<img src="/cool_images/ajax-loader.gif" />
+<img src="http://othersite.com/images/ajax-loader.gif" />

--- a/test/filerev_replace_relative_test.js
+++ b/test/filerev_replace_relative_test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var grunt = require('grunt');
+
+exports.filerev_replace = {
+  js: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/assets/compiled/scripts.js');
+    var expected = grunt.file.read('test/expected/assets/compiled/scripts_relative.js');
+    test.equal(actual, expected);
+
+    test.done();
+  },
+  css: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/assets/compiled/styles.css');
+    var expected = grunt.file.read('test/expected/assets/compiled/styles_relative.css');
+    test.equal(actual, expected);
+
+    test.done();
+  },
+  html: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/views/index.html');
+    var expected = grunt.file.read('test/expected/views/index_relative.html');
+    test.equal(actual, expected);
+
+    test.done();
+  },
+  html_subfolder: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/views/media/index.html');
+    var expected = grunt.file.read('test/expected/views/media/index_relative.html');
+    test.equal(actual, expected);
+
+    test.done();
+  }
+};


### PR DESCRIPTION
I've added the option to use relative root paths. I needed this functionality because a test environment of a website i'm working on resides in a sub-folder on the server http://example.com/test/ and this script was only generating absolute paths to the root.

You can check it out using: 

    options: {
         use_relative_root: true
    },

Let me know what you think.