### PR TITLE
No need to replace relative paths into absolute paths

### DIFF
--- a/test/expected/assets/compiled/scripts.js
+++ b/test/expected/assets/compiled/scripts.js
@@ -2,9 +2,9 @@
 var path = '/images/ajax-loader.4e26f87c.gif';
 
 // Relative path
-var path = '/images/ajax-loader.4e26f87c.gif';
-var path = '/images/ajax-loader.4e26f87c.gif';
-var path = '/images/ajax-loader.4e26f87c.gif';
+var path = '/oops/../images/ajax-loader.4e26f87c.gif';
+var path = '../images/ajax-loader.4e26f87c.gif';
+var path = '../oops/../images/oops/../ajax-loader.4e26f87c.gif';
 
 // Delimiters
 var path = "/images/ajax-loader.4e26f87c.gif";
@@ -16,7 +16,7 @@ var path = '/images/ajax-loader.4e26f87c.gif', path = "/images/ajax-loader.4e26f
 var path = "body { background: url(\"/images/ajax-loader.4e26f87c.gif\"); }";
 
 // Case insensitive
-var path = '/images/ajax-loader.4e26f87c.gif';
+var path = '/IMAGES/ajax-loader.4e26f87c.gif';
 
 // With query string and anchor
 var path = '/images/ajax-loader.4e26f87c.gif?a=b';

--- a/test/expected/assets/compiled/styles.css
+++ b/test/expected/assets/compiled/styles.css
@@ -2,21 +2,21 @@
 body { background: url('/images/ajax-loader.4e26f87c.gif'); }
 
 /* Relative path */
-body { background: url('/images/ajax-loader.4e26f87c.gif'); }
-body { background: url('/images/ajax-loader.4e26f87c.gif'); }
-body { background: url('/images/ajax-loader.4e26f87c.gif'); }
+body { background: url('/oops/../images/ajax-loader.4e26f87c.gif'); }
+body { background: url('../images/ajax-loader.4e26f87c.gif'); }
+body { background: url('../oops/../images/oops/../ajax-loader.4e26f87c.gif'); }
 
 /* Delimiters */
 body { background: url("/images/ajax-loader.4e26f87c.gif"); }
 body { background: url(/images/ajax-loader.4e26f87c.gif); }
-body { background: url(/images/ajax-loader.4e26f87c.gif); }
+body { background: url( /images/ajax-loader.4e26f87c.gif    ); }
 body { background: url('/images/ajax-loader.4e26f87c.gif'); background: url("/images/ajax-loader.4e26f87c.gif"); }
 
 /* Escaped delimiters */
 body { content: "<img src=\"/images/ajax-loader.4e26f87c.gif\" />"; }
 
 /* Case insensitive */
-body { background: url('/images/ajax-loader.4e26f87c.gif'); }
+body { background: url('/IMAGES/ajax-loader.4e26f87c.gif'); }
 
 /* With query string and anchor */
 body { background: url('/images/ajax-loader.4e26f87c.gif?a=b'); }

--- a/test/expected/views/index.html
+++ b/test/expected/views/index.html
@@ -2,15 +2,15 @@
 <img src="/images/ajax-loader.4e26f87c.gif" />
 
 <!-- Relative path -->
-<img src="/images/ajax-loader.4e26f87c.gif" />
-<img src="/images/ajax-loader.4e26f87c.gif" />
-<img src="/images/ajax-loader.4e26f87c.gif" />
+<img src="/oops/../images/ajax-loader.4e26f87c.gif" />
+<img src="images/ajax-loader.4e26f87c.gif" />
+<img src="oops/../images/oops/../ajax-loader.4e26f87c.gif" />
 
 <!-- Delimiters -->
 <img src="/images/ajax-loader.4e26f87c.gif" /><img src="/images/ajax-loader.4e26f87c.gif" />
 
 <!-- Case insensitive -->
-<img src="/images/ajax-loader.4e26f87c.gif" />
+<img src="/IMAGES/ajax-loader.4e26f87c.gif" />
 
 <!-- With query string and anchor -->
 <img src="/images/ajax-loader.4e26f87c.gif?a=b" />

--- a/test/expected/views/media/index.html
+++ b/test/expected/views/media/index.html
@@ -2,15 +2,15 @@
 <img src="/images/ajax-loader.4e26f87c.gif" />
 
 <!-- Relative path -->
-<img src="/images/ajax-loader.4e26f87c.gif" />
-<img src="/images/ajax-loader.4e26f87c.gif" />
-<img src="/images/ajax-loader.4e26f87c.gif" />
+<img src="/oops/../images/ajax-loader.4e26f87c.gif" />
+<img src="../images/ajax-loader.4e26f87c.gif" />
+<img src="../oops/../images/oops/../ajax-loader.4e26f87c.gif" />
 
 <!-- Delimiters -->
 <img src="/images/ajax-loader.4e26f87c.gif" /><img src="/images/ajax-loader.4e26f87c.gif" />
 
 <!-- Case insensitive -->
-<img src="/images/ajax-loader.4e26f87c.gif" />
+<img src="/IMAGES/ajax-loader.4e26f87c.gif" />
 
 <!-- With query string and anchor -->
 <img src="/images/ajax-loader.4e26f87c.gif?a=b" />


### PR DESCRIPTION
Inspired by #5.

I don't remember why I first opted to replace whole paths by their absolute versions, there's no reason I can think of now. Instead of replacing
`var path = '../oops/../images/ajax-loader.gif';`
into
`var path = '/images/ajax-loader.4e26f87c.gif';`
this PR will only replace the filename, so
`var path = '../oops/../images/ajax-loader.4e26f87c.gif';`