### PR TITLE
Changes the Grunt peer dependency from ~0.4.2 to >=0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Replace references to grunt-filerev files.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.2`
+This plugin requires Grunt `>=0.4.2`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-filerev": "~0.1.0",
-    "grunt": ">=0.4.2"
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
     "grunt": ">=0.4.2"

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-filerev": "~0.1.0",
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.2"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
As suggested on [gruntjs.com](http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released) this pull request changes the Grunt peer dependency from ~0.4.2 to >=0.4.2 to make it working with newer Grunt versions.
